### PR TITLE
Fixing p margin on chrome

### DIFF
--- a/src/molecules/YooSelectButton.sass
+++ b/src/molecules/YooSelectButton.sass
@@ -1,3 +1,6 @@
 .yoo-select
   width: 100%
   max-width: 360px
+
+  p
+    margin: auto


### PR DESCRIPTION
# 🐛 Wrong margin on some browsers
- Some android browsers was rendering incorrectly component's margin, as chrome and edge android